### PR TITLE
BCases-1.2

### DIFF
--- a/BCases-common/src/main/java/dev/by1337/bc/animation/impl/SwordsAnim.java
+++ b/BCases-common/src/main/java/dev/by1337/bc/animation/impl/SwordsAnim.java
@@ -21,8 +21,10 @@ import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.by1337.blib.geom.Vec3d;
 import org.by1337.blib.geom.Vec3f;
@@ -145,7 +147,10 @@ public class SwordsAnim extends AbstractAnimation {
         armorStand.setSmall(true);
         armorStand.setInvisible(true);
         armorStand.setNoGravity(true);
-        armorStand.setEquipment(EquipmentSlot.HEAD, new ItemStack(Material.NETHERITE_SWORD));
+        ItemStack sword = new ItemStack(Material.NETHERITE_SWORD);
+        sword.addUnsafeEnchantment(Enchantment.DAMAGE_ALL, 2);
+        sword.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        armorStand.setEquipment(EquipmentSlot.HEAD, sword);
         armorStand.setHeadPose(
                 new Vec3f(
                         (float) Math.toDegrees(Math.toRadians(180)),

--- a/BCases-plugin/src/main/resources/lang.json
+++ b/BCases-plugin/src/main/resources/lang.json
@@ -10,13 +10,37 @@
       "ru_RU": "&a[✔] &fУспешно выдал &cофлайн&f игроку {} {} ключей от кейса {}",
       "en_UK": "&a[✔] &fSuccessfully gave &coffline&f player {} {} crate keys for {}"
     },
+    "command.give.successfully.multiple": {
+      "ru_RU": "&a[✔] &fУспешно выдал {} игрокам по {} ключей от кейса {}",
+      "en_UK": "&a[✔] &fSuccessfully gave {} players {} crate keys each for {}"
+    },
     "command.take.successfully": {
       "ru_RU": "&a[✔] &fУспешно удалил ключи {} в количестве {} у игрока {}",
       "en_UK": "&a[✔] &fSuccessfully removed {} keys (amount: {}) from player {}"
     },
+    "command.take.successfully.multiple": {
+      "ru_RU": "&a[✔] &fУспешно удалил у {} игроков по {} ключей от кейса {}",
+      "en_UK": "&a[✔] &fSuccessfully removed {} keys from {} players for crate {}"
+    },
     "command.take.failed": {
       "ru_RU": "&c[❌] &fНевозможно удалить ключи у оффлайн игрока!",
       "en_UK": "&c[❌] &fCannot remove keys from an offline player!"
+    },
+    "command.clear.successfully": {
+      "ru_RU": "&a[✔] &fУспешно удалил {} ключей у игрока {}",
+      "en_UK": "&a[✔] &fSuccessfully removed {} keys from player {}"
+    },
+    "command.clear.successfully.offline": {
+      "ru_RU": "&a[✔] &fУспешно удалил {} ключей у &cофлайн&f игрока {}",
+      "en_UK": "&a[✔] &fSuccessfully removed {} keys from &coffline&f player {}"
+    },
+    "command.clear.successfully.multiple": {
+      "ru_RU": "&a[✔] &fУспешно удалил {} ключей у {} игроков",
+      "en_UK": "&a[✔] &fSuccessfully removed {} keys from {} players"
+    },
+    "command.clear.failed": {
+      "ru_RU": "&c[❌] &fНе удалось очистить ключи игрока {}",
+      "en_UK": "&c[❌] &fFailed to clear keys for player {}"
     },
     "command.remove.successfully": {
       "ru_RU": "&a[✔] &fУспешно удалил блок на координатах {} {} {}",

--- a/BCases-plugin/src/main/resources/ru/config.yml
+++ b/BCases-plugin/src/main/resources/ru/config.yml
@@ -6,7 +6,6 @@ database:
   url: 'jdbc:mariadb://<IP>:<PORT>/bcases'
   #url: 'jdbc:mysql://<IP>:<PORT>/bcases' # если у вас mysql то используйте этот url
 
-
 time-format:
   ago: 'назад'
   in: 'через'


### PR DESCRIPTION
Изменения:
- Добавлена подкоманда clear для очистки всех кейсов у игрока.
- В онлайн ники игроков можно использовать звездочку то-есть всем онлайн игрокам. (Пример /bcases give * donate 1) 
- Исправлено проигрывание анимации.  
- Мечи в анимации SwordAnim теперь зачарованны. 

Changes:
- Added a subcommand clear to clear all cases for the player.
- Online players can use an asterisk in their nicknames, which applies to all online players. (Example: /bcases give * donate 1) 
- Fixed animation playback. 
- Swords in the SwordAnim animation are now enchanted.